### PR TITLE
updating dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "uvu": "0.5.1"
   },
   "dependencies": {
-    "@tinyhttp/cookie": "2.0.1",
-    "@tinyhttp/cookie-signature": "2.0.1"
+    "@tinyhttp/cookie": "^2.0.1",
+    "@tinyhttp/cookie-signature": "^2.0.1"
   }
 }


### PR DESCRIPTION
avoid duplication of importing dependency if we use "^x.x.x", instead of "x.x.x"